### PR TITLE
Implement config options and user credentials setting from iOS native…

### DIFF
--- a/ios/sdk/src/JitsiMeetConferenceOptions.h
+++ b/ios/sdk/src/JitsiMeetConferenceOptions.h
@@ -37,6 +37,10 @@
  * JWT token used for authentication.
  */
 @property (nonatomic, copy, nullable) NSString *token;
+/**
+ * Jitsi conference config used instead of remote config.js, json object as string
+ */
+@property (nonatomic, copy, nullable) NSString *configJsonString;
 
 /**
  * Color scheme override, see:
@@ -80,6 +84,7 @@
 @property (nonatomic, copy, nullable, readonly) NSString *room;
 @property (nonatomic, copy, nullable, readonly) NSString *subject;
 @property (nonatomic, copy, nullable, readonly) NSString *token;
+@property (nonatomic, copy, nullable, readonly) NSString *configJsonString;
 
 @property (nonatomic, copy, nullable) NSDictionary *colorScheme;
 @property (nonatomic, readonly, nonnull) NSDictionary *featureFlags;

--- a/ios/sdk/src/JitsiMeetConferenceOptions.m
+++ b/ios/sdk/src/JitsiMeetConferenceOptions.m
@@ -43,6 +43,7 @@ static NSString *const WelcomePageEnabledFeatureFlag = @"welcomepage.enabled";
         _room = nil;
         _subject = nil;
         _token = nil;
+        _configJsonString = nil;
 
         _colorScheme = nil;
         _featureFlags = [[NSMutableDictionary alloc] init];
@@ -158,6 +159,7 @@ static NSString *const WelcomePageEnabledFeatureFlag = @"welcomepage.enabled";
         _room = builder.room;
         _subject = builder.subject;
         _token = builder.token;
+        _configJsonString = builder.configJsonString;
 
         _colorScheme = builder.colorScheme;
 
@@ -223,6 +225,10 @@ static NSString *const WelcomePageEnabledFeatureFlag = @"welcomepage.enabled";
 
     if (_token != nil) {
         urlProps[@"jwt"] = _token;
+    }
+    
+    if (_configJsonString != nil) {
+        props[@"configJsonString"] = _configJsonString;
     }
 
     if (_userInfo != nil) {

--- a/ios/sdk/src/JitsiMeetUserInfo.h
+++ b/ios/sdk/src/JitsiMeetUserInfo.h
@@ -30,9 +30,19 @@
  * URL for the user avatar.
  */
 @property (nonatomic, copy, nullable) NSURL *avatar;
+/**
+ * UserId to log in as userId@domain.com
+ */
+@property (nonatomic, copy, nullable) NSString *userId;
+/**
+ * Password to log in
+ */
+@property (nonatomic, copy, nullable) NSString *password;
 
 - (instancetype _Nullable)initWithDisplayName:(NSString *_Nullable)displayName
                                      andEmail:(NSString *_Nullable)email
-                                    andAvatar:(NSURL *_Nullable) avatar;
+                                    andAvatar:(NSURL *_Nullable) avatar
+                                    andUserId:(NSString *_Nullable)userId
+                                  andPassword:(NSString *_Nullable)password;
 
 @end

--- a/ios/sdk/src/JitsiMeetUserInfo.m
+++ b/ios/sdk/src/JitsiMeetUserInfo.m
@@ -20,12 +20,16 @@
 
 - (instancetype)initWithDisplayName:(NSString *)displayName
                            andEmail:(NSString *)email
-                          andAvatar:(NSURL *_Nullable) avatar {
+                          andAvatar:(NSURL *_Nullable) avatar
+                          andUserId:(NSString * _Nullable)userId
+                        andPassword:(NSString * _Nullable)password{
     self = [super init];
     if (self) {
         self.displayName = displayName;
         self.email = email;
         self.avatar = avatar;
+        self.userId = userId;
+        self.password = password;
     }
 
     return self;
@@ -47,6 +51,14 @@
         if (avatarURL != nil) {
             dict[@"avatarURL"] = avatarURL;
         }
+    }
+
+    if (self.userId != nil) {
+        dict[@"userId"] = self.userId;
+    }
+
+    if (self.password != nil) {
+        dict[@"password"] = self.password;
     }
 
     return dict;

--- a/react/features/app/components/App.native.js
+++ b/react/features/app/components/App.native.js
@@ -3,6 +3,7 @@
 import React from 'react';
 
 import { setColorScheme } from '../../base/color-scheme';
+import { storeConfig } from '../../base/config';
 import { DialogContainer } from '../../base/dialog';
 import { updateFlags } from '../../base/flags/actions';
 import { CALL_INTEGRATION_ENABLED, SERVER_URL_CHANGE_ENABLED } from '../../base/flags/constants';
@@ -44,7 +45,12 @@ type Props = AbstractAppProps & {
     /**
      * An object with user information (display name, email, avatar URL).
      */
-    userInfo: ?Object
+    userInfo: ?Object,
+
+    /**
+     * Conference config as json string.
+     */
+    configJsonString: ?string
 };
 
 /**
@@ -102,6 +108,21 @@ export class App extends AbstractApp {
                     if (typeof serverURL !== 'undefined') {
                         dispatch(updateSettings({ serverURL }));
                     }
+                }
+            }
+
+            // handle config set by native app
+            if (typeof this.props.configJsonString === 'string') {
+                try {
+                    const config = JSON.parse(this.props.configJsonString);
+                    const url = `${this.props.url.serverURL}/${this.props.url.room}`;
+
+                    logger.info('Config from native app: \n', config);
+
+                    dispatch(storeConfig(url, config));
+                    this._openURL(url);
+                } catch (e) {
+                    logger.error('Something went wrong at parsing config json string', e);
                 }
             }
 

--- a/react/features/authentication/middleware.js
+++ b/react/features/authentication/middleware.js
@@ -8,7 +8,7 @@ import {
     CONFERENCE_JOINED,
     CONFERENCE_LEFT
 } from '../base/conference';
-import { CONNECTION_ESTABLISHED, CONNECTION_FAILED } from '../base/connection';
+import { connect, CONNECTION_ESTABLISHED, CONNECTION_FAILED, toJid } from '../base/connection';
 import { hideDialog, isDialogOpen } from '../base/dialog';
 import {
     JitsiConferenceErrors,
@@ -114,7 +114,15 @@ MiddlewareRegistry.register(store => next => action => {
                 && error.name === JitsiConnectionErrors.PASSWORD_REQUIRED
                 && typeof error.recoverable === 'undefined') {
             error.recoverable = true;
-            store.dispatch(_openLoginDialog());
+
+            // instead of show login form, login user with credentials set by native app
+            const { jid, password } = _getCredentials(store.getState());
+
+            if (jid && password) {
+                store.dispatch(connect(jid, password));
+            } else {
+                store.dispatch(_openLoginDialog());
+            }
         }
         break;
     }
@@ -174,4 +182,21 @@ function _hideLoginDialog({ dispatch }: { dispatch: Dispatch<any> }) {
  */
 function _isWaitingForOwner({ getState }: { getState: Function }) {
     return Boolean(getState()['features/authentication'].waitForOwnerTimeoutID);
+}
+
+/**
+ * Read credentials from Redux state set by native app.
+ *
+ * @param {Object} state - The redux state.
+ * @returns {{password: string, jid: string}}
+ */
+function _getCredentials(state: Object) {
+    const { userId, password } = state['features/base/participants'].find(participant => participant.local);
+    const { hosts: configHosts } = state['features/base/config'];
+    const jid = toJid(userId, configHosts);
+
+    return {
+        jid,
+        password
+    };
 }


### PR DESCRIPTION
**Origin behavior**:

- User has to add her email and password in a login popup to join the videoconf.
- Jitsi reads conference config from config.js file on remote server.

**New behavior**:

- New properties in native iOS interfaces to add necessary data:
    - userId: we use 'userId@domain.com' as email to login, (domain is set as part of config)
    - password: we use generated JTW token as password
    - configJsonString: we can add config options as a JSON string (currently used options are in JitsiMeetBridgeServiceBase methods).
- Using this new information to automatically login user and set conference config.