### PR TITLE
Vs 2901 add head revision id to the version

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+JITSI_MEET_WORKSPACE={ABSOLUTE_PATH_TO}\jitsi-meet\
+MAVEN_REPOSITORY=~\.m2\repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,93 @@
+FROM openjdk:8-jdk-stretch
+
+# Install dependencies
+RUN apt-get update && \
+	apt-get install -y dos2unix && \
+	apt-get install -y jq && \
+	apt-get install -y maven && \
+	apt-get install -y unzip && \
+	apt-get install -y curl && \
+	apt-get install -y wget
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN apt-get install -y nodejs && \
+	apt-get install -y npm
+
+# Setting up environment variables
+ENV SDK_URL="https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip"
+ENV ANDROID_HOME="/opt/android-sdk"
+ENV PATH "$PATH:$ANDROID_HOME/cmdline-tools/tools/bin"
+RUN export ANDROID_HOME=$ANDROID_HOME
+
+# Download Android SDK
+# https://developer.android.com/studio#command-tools
+RUN mkdir -p "$ANDROID_HOME"/cmdline-tools .android && \
+	cd "$ANDROID_HOME"/cmdline-tools && \
+	curl -o sdk.zip $SDK_URL && \
+	unzip sdk.zip && \
+	rm sdk.zip && \
+	yes | sdkmanager --licenses
+
+# Download latest version of ADB
+RUN wget https://dl.google.com/android/repository/platform-tools-latest-linux.zip && \
+    unzip \platform-tools-latest-linux.zip && \
+    cp platform-tools/adb /usr/bin/adb
+
+VOLUME /jitsi-meet/android/scripts
+
+
+# Setting up working directories
+RUN mkdir -p /jitsi-meet/android/sdk/repo && \
+    mkdir -p /jitsi-meet/android/scripts
+WORKDIR /jitsi-meet
+
+# Running npm i beforehand
+COPY package.json /jitsi-meet/package.json
+COPY package-lock.json /jitsi-meet/package-lock.json
+
+RUN npm i
+
+# Copying build scripts
+COPY android/scripts android/scripts
+COPY android/gradlew android/gradlew
+COPY android/build.gradle android/build.gradle
+COPY android/sdk/build.gradle android/sdk/build.gradle
+
+# Perform dos2unix on executables
+RUN dos2unix /jitsi-meet/android/gradlew
+RUN dos2unix /jitsi-meet/android/build.gradle
+RUN dos2unix /jitsi-meet/android/sdk/build.gradle
+RUN dos2unix /jitsi-meet/android/scripts/release-sdk.sh
+RUN dos2unix /jitsi-meet/android/scripts/run-packager.sh
+RUN dos2unix /jitsi-meet/android/scripts/run-packager-helper.command
+
+# cleanup
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/*
+
+COPY run.sh /run.sh
+RUN dos2unix /run.sh
+CMD [ "/run.sh" ]
+
+### To build the container run these commands from /jitsi-meet:
+# docker build -t jitsi-build .
+
+
+# docker run -d -it --name jitsi-build --mount type=bind,source=<ABSOLUTE_PATH_TO>/jitsi-meet,target=/jitsi-meet --mount type=bind,source=<ABSOLUTE_PATH_TO>/jitsi-maven-repository,target=/jitsi-maven-repository -v /jitsi-meet/node_modules -v /jitsi-meet/android/scripts -p 4300:8080 -p 4301:8081 -p 5555:5555 jitsi-build
+
+### Note that node modules are managed separately (they are excluded from the mount to speed up the build process)
+### If you need to change package.json after building the container, you'll need to run 'docker exec -it jitsi-build npm i' before your next build
+
+### To build your production Android SDK run the following commands:
+# docker exec -it jitsi-build /bin/bash
+# ./android/scripts/release-sdk.sh /jitsi-maven-repository
+
+### To deploy the react-native frontend to an external device follow these steps:
+# 1) Connect an external device to the same wifi network you use for your dev machine
+# 2) Run 'adb start-server' and 'adb tcpip 5555' on your host machine
+# 3) Run 'adb connect <DEVICE_IP>' in the docker container
+#    If 'adb devices' lists your device as unauthorized, you'll need to allow your dev machine to connect to the device
+#    Make sure the device remembers this decision
+#    Run 'adb disconnect <DEVICE_IP> && adb connect <DEVICE_IP>' in the container
+# 4) Run 'npx react-native start' in a separate docker terminal
+# 5) After that's finished, run 'npx react-native run-android'

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,26 +68,3 @@ RUN apt-get clean && \
 COPY run.sh /run.sh
 RUN dos2unix /run.sh
 CMD [ "/run.sh" ]
-
-### To build the container run these commands from /jitsi-meet:
-# docker build -t jitsi-build .
-
-
-# docker run -d -it --name jitsi-build --mount type=bind,source=<ABSOLUTE_PATH_TO>/jitsi-meet,target=/jitsi-meet --mount type=bind,source=<ABSOLUTE_PATH_TO>/jitsi-maven-repository,target=/jitsi-maven-repository -v /jitsi-meet/node_modules -v /jitsi-meet/android/scripts -p 4300:8080 -p 4301:8081 -p 5555:5555 jitsi-build
-
-### Note that node modules are managed separately (they are excluded from the mount to speed up the build process)
-### If you need to change package.json after building the container, you'll need to run 'docker exec -it jitsi-build npm i' before your next build
-
-### To build your production Android SDK run the following commands:
-# docker exec -it jitsi-build /bin/bash
-# ./android/scripts/release-sdk.sh /jitsi-maven-repository
-
-### To deploy the react-native frontend to an external device follow these steps:
-# 1) Connect an external device to the same wifi network you use for your dev machine
-# 2) Run 'adb start-server' and 'adb tcpip 5555' on your host machine
-# 3) Run 'adb connect <DEVICE_IP>' in the docker container
-#    If 'adb devices' lists your device as unauthorized, you'll need to allow your dev machine to connect to the device
-#    Make sure the device remembers this decision
-#    Run 'adb disconnect <DEVICE_IP> && adb connect <DEVICE_IP>' in the container
-# 4) Run 'npx react-native start' in a separate docker terminal
-# 5) After that's finished, run 'npx react-native run-android'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.2"
+
+services:
+  # Docker container for building jitsi-sdk on windows
+  jitsi-build:
+    container_name: jitsi-build
+    build: .
+    image: jitsi-build
+    stdin_open: true # docker run -i
+    tty: true        # docker run -t
+    ports:
+      - 4300:8080 
+      - 4301:8081
+      - 5555:5555
+    volumes:
+      - type: bind
+        source: ${JITSI_MEET_WORKSPACE}
+        target: /jitsi-meet
+      - type: bind
+        source: ${MAVEN_REPOSITORY}
+        target: /jitsi-maven-repository
+      
+      # Keeping node_modules and scripts folders inside the docker container 
+      # makes the build faster. Note: files in the scripts folder gets copied 
+      # into the container due the COPY commands in the dockerfile.
+      
+      # node_modules folder will be placed inside the docker container
+      - /jitsi-meet/node_modules 
+      # scripts folder will be placed inside the docker container
+      - /jitsi-meet/android/scripts

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+touch local.properties
+touch android/local.properties
+echo "sdk.dir=$ANDROID_HOME" > local.properties
+echo "sdk.dir=$ANDROID_HOME" > android/local.properties
+
+/bin/bash

--- a/sonrisa-README.md
+++ b/sonrisa-README.md
@@ -22,7 +22,47 @@
 ```
 ### [Android](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-android-sdk)
 ##### Build in Windows
-Currently building the application is not supported on Windows, for this purpose you can use the Dockerfile (and run.sh) from the dockerize-android-sdk-build branch. This contains all dependencies required by this project and a short howto on usage.
+Currently building the application is not supported on Windows. 
+For being able to build jitsi-SDK on Windows we created a docker container so the build process can be executed inside the container.
+
+You have two options to use the docker container:
+
+###### Using docker-compose
+First of you need to set the absolute path of the jitsi-meet workspace in the .env file.
+Then for using the docker container for building the SDK please do the followings:
+```
+$ cd jitsi-meet
+$ docker-compose up -d
+```
+Now you have the running docker container that can be used for building the SDK. Go and jump to the common part.
+
+###### Using docker CLI
+First you need to build the docker image with this command:
+```
+$ docker build -t jitsi-build .
+```
+Then you can start the docker container:
+```
+$ docker run -d -it --name jitsi-build --mount type=bind,source=<ABSOLUTE_PATH_TO>/jitsi-meet,target=/jitsi-meet --mount type=bind,source=<ABSOLUTE_PATH_TO>/jitsi-maven-repository,target=/jitsi-maven-repository -v /jitsi-meet/node_modules -v /jitsi-meet/android/scripts -p 4300:8080 -p 4301:8081 -p 5555:5555 jitsi-build 
+```
+The `<ABSOLUTE_PATH_TO>/jitsi-meet` should be the full path of your jitsi-meet workspace. 
+The `<ABSOLUTE_PATH_TO>/jitsi-maven-repository` should be the full path of the maven repository where you want to push the SDK binary, something like `c:\users\{USER_NAME}\.m2\repository`.
+
+Now you have the running docker container that can be used for building the SDK. From this point you can follow the instructions above in the common part.
+
+###### Common part
+
+```
+$ docker exec -it jitsi-build /bin/bash 
+# npm i
+# ./android/scripts/release-sdk.sh /jitsi-maven-repository dev
+```
+
+ - Once the build is ready, you'll find your results in the `~\.m2\repository\org\jitsi\react\jitsi-meet-sdk` folder.
+ - If you want to change the path of the targeted maven repository, you can do that in the .env docker environment file.
+ - By passing the `dev` argument to the `release-sdk.sh` script the current git head revisionID will be appended to the version of the SDK. This is useful especially when you're switching between different branches because it keeps the different SDK versions in your maven repository, so you don't have to rebuild the SDK on each branch. 
+ - If you want to produce a production SDK build, then do not pass the `dev` argument. Production build is the default. 
+ 
 
 ##### Build in Mac/Linux
 To build the jitsi meet SDK for android, run the following commands from the project' root directory:

--- a/sonrisa-README.md
+++ b/sonrisa-README.md
@@ -25,10 +25,10 @@
 Currently building the application is not supported on Windows. 
 For being able to build jitsi-SDK on Windows we created a docker container so the build process can be executed inside the container.
 
-You have two options to use the docker container:
+You have two options to use the docker container. It can be started by using docker-compose or you can build and start the container by using the docker command line interface. Both will end up with the same docker container, choose based on your personal preference. 
 
 ###### Using docker-compose
-First of you need to set the absolute path of the jitsi-meet workspace in the .env file.
+First of you need to set the absolute path of the jitsi-meet workspace in the .env file. (If you want to change the path of the targeted maven repository, you can also do that in the .env file.)
 Then for using the docker container for building the SDK please do the followings:
 ```
 $ cd jitsi-meet
@@ -58,11 +58,24 @@ $ docker exec -it jitsi-build /bin/bash
 # ./android/scripts/release-sdk.sh /jitsi-maven-repository dev
 ```
 
+**Notes:**
+
  - Once the build is ready, you'll find your results in the `~\.m2\repository\org\jitsi\react\jitsi-meet-sdk` folder.
- - If you want to change the path of the targeted maven repository, you can do that in the .env docker environment file.
  - By passing the `dev` argument to the `release-sdk.sh` script the current git head revisionID will be appended to the version of the SDK. This is useful especially when you're switching between different branches because it keeps the different SDK versions in your maven repository, so you don't have to rebuild the SDK on each branch. 
  - If you want to produce a production SDK build, then do not pass the `dev` argument. Production build is the default. 
- 
+ - Note that node modules are managed separately (they are excluded from the mount to speed up the build process). If you need to change package.json after building the container, you'll need to run 'docker exec -it jitsi-build npm i' before your next build.
+ - Also note, that the scripts folder isn't mounted, but rather the files are copied inside the continer. So if you make any changes in the buld script, you need to copy the file to the container again: `docker cp release-sdk.sh jitsi-build:/jitsi-meet/android/scripts/release-sdk.sh`
+
+###### How to deploy the react-native frontend to an external device
+
+1) Connect an external device to the same wifi network you use for your dev machine
+2) Run `adb start-server` and `adb tcpip 5555` on your host machine
+3) Run `adb connect <DEVICE_IP>` in the docker container
+   If `adb devices` lists your device as unauthorized, you'll need to allow your dev machine to connect to the device
+   Make sure the device remembers this decision
+   Run `adb disconnect <DEVICE_IP> && adb connect <DEVICE_IP>` in the container
+4) Run `npx react-native start` in a separate docker terminal
+5) After that's finished, run `npx react-native run-android`
 
 ##### Build in Mac/Linux
 To build the jitsi meet SDK for android, run the following commands from the project' root directory:


### PR DESCRIPTION
VS-2901 Add git head revision ID to the version of the jitsi-SDK binary and creating dockerized build tool for win

Changes:
- A dockerfile is added that defines a docker image that is prepared for building the jitsi-meet SDK. Useful for Windows OS where the SDK cannot be built.
- A docker-compose and a .env file is added that help to run the docker container by containing a default setup.
- Changes were made in the release script to append the git head revisionID to the version of the SDK if it is built in dev mode.
- Readme is updated accordingly.
