### PR TITLE
VS-2927 - fix z-axis ordering of infocus and selfframe

### DIFF
--- a/react/features/filmstrip/components/native/InFocusView.js
+++ b/react/features/filmstrip/components/native/InFocusView.js
@@ -93,6 +93,7 @@ class InFocusView extends Component<Props> {
                     participant = { this.props.inFocusUser }
                     renderDisplayName = { true }
                     styleOverrides = { styles.fillView }
+                    zOrder = { 0 }
                     tileView = { true } />
 
                 {!_.isNil(this.props.inFocusUser)
@@ -163,6 +164,7 @@ class InFocusView extends Component<Props> {
                     isAvatarCircled = { false }
                     participant = { this.props.localUser }
                     renderDisplayName = { true }
+                    zOrder = { 1 }
                     styleOverrides = {{
                         ...styles.fillView,
                         borderRadius: 15

--- a/react/features/filmstrip/components/native/Thumbnail.js
+++ b/react/features/filmstrip/components/native/Thumbnail.js
@@ -89,7 +89,14 @@ type Props = {
     /**
      * Indicates whether shown in front view or not.
      */
-    isAvatarCircled: boolean
+    isAvatarCircled: boolean,
+
+    /**
+     * The z-order of the {@link Video} of {@link ParticipantView} in the
+     * stacking space of all {@code Video}s. For more details, refer to the
+     * {@code zOrder} property of the {@code Video} class for React Native.
+     */
+    zOrder?: number,
 }
 
 /**
@@ -102,7 +109,6 @@ class Thumbnail extends Component<Props> {
 
     render() {
         const participantId = _.isNil(this.props.participant?.id) ? 0 : this.props.participant.id;
-
         return (
             <Container
                 onClick = { this.props._onClick }
@@ -119,6 +125,7 @@ class Thumbnail extends Component<Props> {
                     participantId = { participantId }
                     style = { styles.participantViewStyle }
                     tintEnabled = { false }
+                    zOrder = {this.props.zOrder}
                     tintStyle = { styles.activeThumbnailTint } />
 
                 <LinearGradient


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
